### PR TITLE
remove Twitter

### DIFF
--- a/_drafts/2014-01-01-18f-ffd.md
+++ b/_drafts/2014-01-01-18f-ffd.md
@@ -1,18 +1,15 @@
 ---
 layout: project
-permalink: /us-web-design-standards/
-short-title:  "U.S. Web Design Standards"
-long-title: "U.S. Web Design Standards"
+permalink: /federal-front-door/
+short-title:  "Federal Front Door"
+long-title: "Federal Front Door discovery research"
 categories: ux
-thumbnail: "wds-homepage-thumb-@2x.png" 
+thumbnail: " " 
 mobile-image: " "
 img-path: '../img/'
 ---
 
 ## Brief ##
-
-The [U.S. Web Design Standards](https://standards.usa.gov) is an open-source pattern library and visual style guide to help government agencies quickly stand up accessible and responsive websites. I was on the initial team that took the standards from proposal to initial (alpha) release. 
-
 
 <figure>
 	<img src="{{ page.img-path }}/wds-affinity-mapping.png" alt="Results of an affinity mapping session" />
@@ -71,14 +68,3 @@ The [U.S. Web Design Standards](https://standards.usa.gov) is an open-source pat
 </ul>
 
 ## Results ##
-
-The [U.S. Web Design Standards](https://standards.usa.gov) launched an alpha version in the fall of 2015 to wide acclaim. The [GitHub repo](https://github.com/18F/web-design-standards) quickly became 18F’s most forked (over 500 copies) and starred (over 3,000 stars) project. Teams from various federal agencies have reported back on its ease of use, accessible foundation, and clean design, while also saving the team on development time. 
-
-The standards have been used in projects for the Veterans Affairs Administration, the Office of Personnel Management ([USAJobs.gov](https://www.usajobs.gov)), the Environmental Protection Agency ([epa.gov](https://www.epa.gov)), and [various other public and private sector organizations](https://github.com/18F/web-design-standards/blob/staging/WHO_IS_USING_USWDS.md). 
-
-We also got some pretty great Tweets. 
-<figure>
-	<img src="{{ page.img-path }}/wds-Tweet-1-@2x.png" alt="Tweet from Jeb Bush praising the web design standards" longdesc="A tweet from Jeb Bush saying 'Gov't should be accessible & easy for the public to interact with. New web design standards are a good step forward.'">
-	<img src="{{ page.img-path }}/wds-tweet-two@2x.png" alt="A tweet praising the standards" longdesc="A tweet from @stefanhartwig saying 'There are times when being a gubment employee is incredibly enticing. This is a dream gig for me' and linking to a blog post about the web design standards">
-	<img src="{{ page.img-path }}/wds-tweet-three@2x.png" alt="Another tweet standards" longdesc="Tweet from @erikschmidt saying, 'Years ago I ran a government website. Something like this would have been really handy,' with a link to the original URL for the web design standards" >
-</figure>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,6 @@
 	</nav>
 	<div class= "footer-social">
 		<a class="li" id="linkedin" href="http://www.linkedin.com/in/carolyndew" title="Straight-laced profile you can show your boss." onclick="_gaq.push(['_trackEvent', 'Social','Footer','Linkedin']);">Linkedin</a>
-		<a class="tw" id="twitter" href="https://twitter.com/carodew" title="Design-related tweets mixed with me trying to be funny." onclick="_gaq.push(['_trackEvent', 'Social','Footer', 'Twitter']);">Twitter</a>
 		<a class="pin" id="pinterest" href="http://pinterest.com/caslondew/" title="See what inspires and entertains me." onclick="_gaq.push(['_trackEvent', 'Social','Footer','Pinterest']);">Pinterest</a>
 	</div>
 

--- a/about.md
+++ b/about.md
@@ -31,7 +31,6 @@ img-path: "../img"
 		</p>
 	<div class="social">
 	<a class="li" id="linkedin" href="http://www.linkedin.com/in/carolyndew" title="Straight-laced profile you can show your boss." onclick="_gaq.push(['_trackEvent', 'Social','Click','Linkedin']);">Linkedin</a>
-	<a class="tw" id="twitter" href="https://twitter.com/carodew" title="Design-related tweets mixed with me trying to be funny." onclick="_gaq.push(['_trackEvent', 'Social','Click', 'Twitter']);">Twitter</a>
 	<a class="pin" id="pinterest" href="http://pinterest.com/caslondew/" title="See what inspires and entertains me." onclick="_gaq.push(['_trackEvent', 'Social','Click','Pinterest']);">Pinterest</a>
 	</div>
 	</div>


### PR DESCRIPTION
I've thought a lot about how I interact with the world since the election – not just because of the election but also due to a growing distrust of the social media forums I've participated in. I've been distressed at the large amounts of time I've spent consuming snippets of not very deep, thoughtful, or nuanced content online. I've grown increasingly resentful at social media's use of addictive patterns to manipulate my attention towards their advertisers. And I've been increasingly alarmed at the 'monkey mind' chatter I've noticed in myself after using social media. 

I've long since deleted Facebook and don't regret it – I spend more time reading and relaxing and guess what? I'm still in touch with the people I truly care about. I've not logged in to my Twitter account since February, which has only given me back more time to spend reading or engaging in activities that promote deeper reflection or thinking. 

It's time to delete Twitter for good. 

Linkedin, you're on notice. 